### PR TITLE
correct the description of date getTimezoneOffset

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/date/gettimezoneoffset/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/gettimezoneoffset/index.html
@@ -21,7 +21,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
 
 <h3 id="Description" name="Description">返回值</h3>
 
-<p>时区偏差（time-zone offset）表示协调世界时（UTC）与本地时区之间的差值，单位为分钟。需要注意的是如果本地时区先于协调世界时，则该差值为正值，如果后于协调世界时则为负值。例如你所在时区为 UTC+10（澳大利亚东部标准时间），将会返回 -600。对于同一个时区，夏令时（Daylight Saving Time）将会改变这个值。</p>
+<p>时区偏差（time-zone offset）表示协调世界时（UTC）与本地时区之间的差值，单位为分钟。需要注意的是如果本地时区后于协调世界时，则该差值为正值，如果先于协调世界时则为负值。例如你所在时区为 UTC+10（澳大利亚东部标准时间），将会返回 -600。对于同一个时区，夏令时（Daylight Saving Time）将会改变这个值。</p>
 
 <h2 id="Examples" name="Examples">例子</h2>
 


### PR DESCRIPTION
返回值部分关于正负值的描述有误，英文原文为：
The number of minutes returned by getTimezoneOffset() is positive if the local time zone is behind UTC, and negative if the local time zone is ahead of UTC.